### PR TITLE
Update dockerrotate and rotate script for 2.0.1

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,6 +25,12 @@ docker_uses_upstart: yes
 docker_py_version: 1.2.3
 
 
+# Version of docker-rotate to use.
+#
+# https://github.com/locationlabs/docker-rotate
+docker_rotate_version: 2.0.1
+
+
 # Log rotate interval. Log files will be rotated after this interval.
 
 docker_log_rotate_interval: "daily"

--- a/files/docker-rotate
+++ b/files/docker-rotate
@@ -1,4 +1,7 @@
 #!/bin/sh
 
-# Remove docker image and container garbage with docker-rotate
-docker-rotate --clean-images --keep 3 --clean-containers
+# Remove docker images keeping the last 3 of each type
+docker-rotate images --keep 3
+# Remove docker containers that have exited over an hour ago
+# and were created over a day ago
+docker-rotate containers --exited 1h --created 1d

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
   pip: name=docker-py version="{{ docker_py_version }}"
 
 - name: install docker-rotate
-  pip: name=dockerrotate
+  pip: name=dockerrotate version="{{ docker_rotate_version}}"
 
 - name: install docker-rotate cron script
   copy: src=docker-rotate dest=/etc/cron.daily/ mode=755
@@ -21,7 +21,7 @@
 
 - name: push docker configuration
   template: src=docker.j2 dest=/etc/default/docker
-  notify: restart docker  
+  notify: restart docker
 
 - name: install docker-compose
   pip:


### PR DESCRIPTION
- With docker-rotate 2 arg parsing changed and the rotate cron script is
  incompatible.

`docker-rotate --clean-images` is now supported with `docker-rotate images`
`docker-rotate --clean-containers` is now supported with `docker-rotate containers`

Signed-off-by: Patrick Hull patrick.hull@locationlabs.com
