### PR TITLE
exclude containers based on busybox from cleanup

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,6 +31,11 @@ docker_py_version: 1.2.3
 docker_rotate_version: 2.0.1
 
 
+# Python regex of image names to remove. Use a '~' prefix for negative match.
+#
+# https://github.com/locationlabs/docker-rotate
+docker_rotate_containers_images_filter: ~busybox
+
 # Log rotate interval. Log files will be rotated after this interval.
 
 docker_log_rotate_interval: "daily"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,7 +34,7 @@ docker_rotate_version: 2.0.1
 # Python regex of image names to remove. Use a '~' prefix for negative match.
 #
 # https://github.com/locationlabs/docker-rotate
-docker_rotate_containers_images_filter: ~busybox
+docker_rotate_containers_images_regex: ~busybox
 
 # Log rotate interval. Log files will be rotated after this interval.
 

--- a/files/docker-rotate
+++ b/files/docker-rotate
@@ -3,5 +3,6 @@
 # Remove docker images keeping the last 3 of each type
 docker-rotate images --keep 3
 # Remove docker containers that have exited over an hour ago
-# and were created over a day ago
-docker-rotate containers --exited 1h --created 1d
+# and were created over a day ago>  Exclude containers based on busybox
+# which are typically used for data volumes.
+docker-rotate containers --exited 1h --created 1d --images ~busybox

--- a/files/docker-rotate
+++ b/files/docker-rotate
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-# Remove docker images keeping the last 3 of each type
-docker-rotate images --keep 3
-# Remove docker containers that have exited over an hour ago
-# and were created over a day ago>  Exclude containers based on busybox
-# which are typically used for data volumes.
-docker-rotate containers --exited 1h --created 1d --images ~busybox

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,7 @@
   pip: name=dockerrotate version="{{ docker_rotate_version}}"
 
 - name: install docker-rotate cron script
-  copy: src=docker-rotate dest=/etc/cron.daily/ mode=755
+  template: src=docker-rotate dest=/etc/cron.daily/ mode=755
 
 - name: push logrotate config file for docker container json logs
   template: src=logrotate.conf.j2 dest=/etc/logrotate.d/docker

--- a/templates/docker-rotate
+++ b/templates/docker-rotate
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Remove docker images keeping the last 3 of each type
+docker-rotate images --keep 3
+# Remove docker containers that have exited over an hour ago
+# and were created over a day ago
+docker-rotate containers --exited 1h --created 1d --images {{ docker_rotate_containers_images_filter }}

--- a/templates/docker-rotate
+++ b/templates/docker-rotate
@@ -4,4 +4,4 @@
 docker-rotate images --keep 3
 # Remove docker containers that have exited over an hour ago
 # and were created over a day ago
-docker-rotate containers --exited 1h --created 1d --images {{ docker_rotate_containers_images_filter }}
+docker-rotate containers --exited 1h --created 1d --images {{ docker_rotate_containers_images_regex }}


### PR DESCRIPTION
In docker-rotate 2.0, the logic was changed so that the developer needs to filter by base image to determine if it's a "volume container" instead of inferring it based on association with a volume.  At present, data container volumes are destroyed.

Alternatively, if filtering based on image seems risky, we could (1) go back to the 1.x series of docker-rotate or (2) modify docker-rotate to have an option to use inferential filtering.

AWS-196
