### PR TITLE
Switch out requests_version for docker_base_extra_python_requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ This role expects the following variables:
  - `docker_rotate_version` defines the version of the Docker Rotate library to install, default 3.0
  - `docker_compose_version` defines the version of Docker Compose to install, may be "latest",
    default 1.8.0. To skip installation of docker_compose, specify `null` or `""`
+ - `docker_base_extra_python_requirements`: defines a list of extra python requirements you may need
+   in the event of a version conflict. Each item of the list is a extra entry in the generated requirements.txt
+   Latest docker-py and docker-compose needed different versions of `requests` so we added this.
+   See Also: `pip requirements sub dependency resolution`
+
+   Example:
+
+     docker_base_extra_python_requirements:
+       - "requests==2.7.0"
+
  - `docker_rotate_images_arguments`: arguments to pass to "docker-rotate images" when cleanup cron
    job runs. If blank, job will not be run. Default is "--keep 3 --name ~busybox --tag ~latest".
    For documentation, see the
@@ -37,9 +47,6 @@ This role expects the following variables:
  - `docker_registries_to_login`: list of maps, each map containing login credentials for a Docker
    registry. Expected keys are `username`, `password`, `email`, and `url`. The role will attempt to
    log into each registry described in the list. Default is empty.
- - `requests_version`: if you want to explicitly install a specific version of requests library. 
-    Latest docker-py and docker-compose need different versions of requests so we have to 
-    explicitly install a specific version of requests library.  
 
 Example for `docker_registries_to_login`:
 
@@ -63,3 +70,15 @@ In order to run this role:
  - python and pip must be installed.
  - docker engine must be installed. For a role that installs docker engine, see
    [here](https://github.com/locationlabs/ansible-role_docker)
+
+## pip requirements sub dependency resolution
+There are times when we will need to be explicit about versions of sub dependencies
+installed so that we ensure that the versions installed are compatible with both
+docker_py and docker_compose as well as any other requirements. We do this since
+pip doesn't have proper sub dependency resolution:
+    https://github.com/pypa/pip/issues/988
+
+We should update `docker_base_extra_python_requirements` as needed when changing
+what we install with pip. Especially if we change default versions of
+`docker_py_version` or `docker_compose_version` since the version of `requests`
+compatible with both could change when this happens.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,8 +20,7 @@ docker_compose_version: "1.8.0"
 # There are times when we will need to be explicit about versions of other libraries
 # See README.md for detals.
 # Empty list means don't specify any additional versions
-docker_base_extra_python_requirements:
-  - "requests==2.7.0"
+docker_base_extra_python_requirements: []
 
 # Version of docker-rotate to use. Versions lower than 3.0 are not supported due
 # to API changes.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,13 @@ docker_py_version: "1.9.0"
 # 'latest' to install the newest version, null or empty string to install nothing.
 docker_compose_version: "1.8.0"
 
+# Extra python requirements.
+# There are times when we will need to be explicit about versions of other libraries
+# See README.md for detals.
+# Empty list means don't specify any additional versions
+docker_base_extra_python_requirements:
+  - "requests==2.7.0"
+
 # Version of docker-rotate to use. Versions lower than 3.0 are not supported due
 # to API changes.
 #

--- a/templates/requirements.txt.j2
+++ b/templates/requirements.txt.j2
@@ -1,8 +1,8 @@
-{% if requests_version is defined %}
-requests{{ '' if requests_version == 'latest' else ('==' + requests_version) }}
-{% endif%}
 docker-py{{ '' if docker_py_version == 'latest' else ('==' + docker_py_version) }}
 dockerrotate=={{ docker_rotate_version }}
 {% if docker_compose_version is not none and docker_compose_version != '' %}
 docker-compose{{ '' if docker_compose_version == 'latest' else ('==' + docker_compose_version) }}
 {% endif %}
+{% for item in docker_base_extra_python_requirements %}
+{{ item }}
+{% endfor %}

--- a/templates/requirements.txt.j2
+++ b/templates/requirements.txt.j2
@@ -1,8 +1,8 @@
+{% for item in docker_base_extra_python_requirements %}
+{{ item }}
+{% endfor %}
 docker-py{{ '' if docker_py_version == 'latest' else ('==' + docker_py_version) }}
 dockerrotate=={{ docker_rotate_version }}
 {% if docker_compose_version is not none and docker_compose_version != '' %}
 docker-compose{{ '' if docker_compose_version == 'latest' else ('==' + docker_compose_version) }}
 {% endif %}
-{% for item in docker_base_extra_python_requirements %}
-{{ item }}
-{% endfor %}


### PR DESCRIPTION
This will allow us to make changes more easily when we encounter this problem again. Added some additional info to the README for those who might not know why we needed the change and future maintainers.
