### PR TITLE
Removed code in this role that managed /etc/default/docker. 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Release Change Log
 
+Version 4.0:
+ - dropped support for "docker_opts", "docker_log_rotate_max_size", and "docker_log_rotate_count"
+   variables. Changing docker default configuration is no longer the repsonsibility of this
+   role.
+
 Version 3.0.2:
  - add variable to define extra python dependencies in case of sub dependency conflicts
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,10 @@
 
 Version 4.0:
  - dropped support for "docker_opts", "docker_log_rotate_max_size", and "docker_log_rotate_count"
-   variables. Changing docker default configuration is no longer the repsonsibility of this
-   role.
+   variables. Changing docker default configuration is no longer the responsibility of this
+   role. (It's intended that this role be used with ansible-role_docker v2.2+, which now
+   supports passing options to Docker on startup.)
+ - see "Migration Notes" in README.md
 
 Version 3.0.2:
  - add variable to define extra python dependencies in case of sub dependency conflicts

--- a/README.md
+++ b/README.md
@@ -39,9 +39,6 @@ This role expects the following variables:
    `docker_rotate_created_containers`: if non-empty, created containers - that is, containers that
    have been created but never started - at least this old will be removed when daily cleanup runs.
    Default is empty.
- - `docker_log_rotate_max_size`: Docker's JSON logs for containers will be rotated when they reach
-   this size. Default 10M.
- - `docker_log_rotate_count`: log files will be rotated this number of times before removal.
  - `docker_images_to_pull`: list of Docker images; images with these names will be "docker pull"ed
    when the role is run. Default is empty.
  - `docker_registries_to_login`: list of maps, each map containing login credentials for a Docker

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Specifically:
    Ansible < 2.0.
 
 ## Dependencies
-In order to run this role:
+In order to run this role against a host:
  - python and pip must be installed.
  - docker engine must be installed. For a role that installs docker engine, see
    [here](https://github.com/locationlabs/ansible-role_docker)
@@ -79,3 +79,37 @@ We should update `docker_base_extra_python_requirements` as needed when changing
 what we install with pip. Especially if we change default versions of
 `docker_py_version` or `docker_compose_version` since the version of `requests`
 compatible with both could change when this happens.
+
+## Migration Notes
+
+### To 4.0
+In v4.0 the `docker_opts`, docker_log_rotate_max_size`, and `docker_log_rotate_count`
+variables were removed. This role no longer directly supports log rotation or docker
+configuration. However, option setting functionality was added to the
+`ansible-role_docker` role in v2.2.
+
+For deployment projects using both roles, this means:
+ - you should migrate to v4.0 and v2.2 at the same time
+ - Any command-line options you were specifying in `docker_opts` for this role should
+   be specified in the `docker_daemon_flags` variable used by the `ansible-role_docker`
+   role.
+ - If you were using the log rotation functionality here, you should add equivalent
+   `\--log-opt` sections to `docker_daemon_flags`
+
+e.g. if your old variables were:
+
+    docker_opts: "--storage-driver=aufs"
+    docker_log_rotate_max_size: 10M
+    docker_log_rotate_count: 3
+
+then your new config could be:
+
+    docker_daemon_flags: >
+      --storage-driver=aufs
+      --log-opt max-size=10M
+      --log-opt max-file=3
+
+IMPORTANT: note that versions of Docker before 1.8 don't support `\--log-opt`, so these
+roles no longer support log rotation for <1.8 versions of Docker. In that case, you can
+keep using old versions of these roles, or have your deploy project write the
+`/etc/logrotate.d/docker` file itself.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,16 +46,6 @@ docker_rotate_exited_containers: "1h"
 # Note that old-style "data" containers are in the "created" state.
 docker_rotate_created_containers: ""
 
-# In Docker <1.8, log rotation is implemented using logrotate; in Docker 1.8+, default Docker
-# settings are used.
-
-# log rotation max size. Log files will rotate when they reach this size.
-docker_log_rotate_max_size: 10M
-
-# Log files are rotated <log_rotate_count> times before being removed.
-# If count is 0, old versions are removed rather then rotated.
-docker_log_rotate_count: 3
-
 # List of docker images to pull (at latest version) when role is run.
 docker_images_to_pull: []
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,28 +36,13 @@
 - name: install docker-rotate cron script
   template: src=docker-rotate.j2 dest=/etc/cron.daily/docker-rotate mode=755
 
-- name: push logrotate config file for docker container json logs
-  template: src=logrotate.conf.j2 dest=/etc/logrotate.d/docker
-  when: installed_docker_version | version_compare('1.8', '<')
-
+# docker log rotation is now managed by Docker (since Docker 1.8). We no longer deal with
+# it in this role. Clean up any old file that might still be around.
 - name: make sure docker logrotate config is removed
   file: state=absent dest=/etc/logrotate.d/docker
-  when: installed_docker_version | version_compare('1.8', '>=')
 
 - name: install docker zombie volumes cleanup cron script
   copy: src=clear-zombie-docker-data-dirs dest=/etc/cron.daily/ mode=755
-
-- name: push docker configuration
-  template: src=docker.j2 dest=/etc/default/docker
-  register: docker_config_result
-  notify: restart docker
-
-# make sure docker restarts to get the newest configuration
-- meta: flush_handlers
-
-- name: gather docker facts
-  setup:
-  when: ansible_docker0 is not defined or docker_config_result | changed
 
 - name: login to docker registry
   command: "docker login -u {{ item.username }} -p {{ item.password }} -e {{ item.email }} {{ item.url }}"

--- a/templates/docker.j2
+++ b/templates/docker.j2
@@ -1,9 +1,0 @@
-# Docker Upstart and SysVinit configuration file
-
-DOCKER_OPTS="
-   {% if docker_opts is defined %}
-      {{ docker_opts }}
-   {%- endif %}
-   {% if docker_version | version_compare('1.8', '>=') -%}
-      --log-opt max-size={{ docker_log_rotate_max_size }} --log-opt max-file={{ docker_log_rotate_count }}
-   {%- endif %}"

--- a/templates/logrotate.conf.j2
+++ b/templates/logrotate.conf.j2
@@ -1,8 +1,0 @@
-/var/lib/docker/containers/*/*-json.log {
-    size {{ docker_log_rotate_max_size }}
-    rotate {{ docker_log_rotate_count }}
-    missingok
-    compress
-    notifempty
-    copytruncate
-}


### PR DESCRIPTION
That's now handled by ansible-role_docker (as of v2.2 of that role.)