### PR TITLE
Fixed an issue with docker_rotate configuration.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Release Change Log
 
+Version 4.0.1:
+ - fixed parameter handling for docker-rotate file
+
 Version 4.0:
  - dropped support for "docker_opts", "docker_log_rotate_max_size", and "docker_log_rotate_count"
    variables. Changing docker default configuration is no longer the responsibility of this

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,7 +26,7 @@ docker_base_extra_python_requirements: []
 # to API changes.
 #
 # https://github.com/locationlabs/docker-rotate
-docker_rotate_version: "3.0"
+docker_rotate_version: "3.0.1"
 
 # These properties govern Docker Rotate configuration. https://github.com/locationlabs/docker-rotate
 

--- a/templates/docker-rotate.j2
+++ b/templates/docker-rotate.j2
@@ -1,17 +1,17 @@
 #!/bin/sh
 
-{% if docker_rotate_images_arguments | bool %}
+{% if docker_rotate_images_arguments is not none and docker_rotate_images_arguments != "" %}
 docker-rotate images {{ docker_rotate_images_arguments }}
 {% endif %}
 
-{% if docker_rotate_untagged_images %}
+{% if docker_rotate_untagged_images|bool %}
 docker-rotate untagged-images
 {% endif %}
 
-{% if docker_rotate_exited_containers != "" %}
+{% if docker_rotate_exited_containers is not none and docker_rotate_exited_containers != "" %}
 docker-rotate containers --exited {{ docker_rotate_exited_containers }}
 {% endif %}
 
-{% if docker_rotate_created_containers != "" %}
+{% if docker_rotate_created_containers is not none and docker_rotate_created_containers != "" %}
 docker-rotate containers --created {{ docker_rotate_created_containers }}
 {% endif %}


### PR DESCRIPTION
Previously, the contents of "docker_rotate_images_arguments" were never written to the cron script for docker-rotate, so image rotation was never run.